### PR TITLE
Adding support to keep a fix ammount of kernels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,23 @@ kthresher
 [![](https://img.shields.io/pypi/pyversions/kthresher.svg)](https://pypi.python.org/pypi/kthresher/)
 [![](https://img.shields.io/pypi/l/kthresher.svg)](https://pypi.python.org/pypi/kthresher/)
 
-Tool to remove unused kernels that were installed automatically in Debian/Ubuntu
+Tool to remove unused kernels that were installed automatically in Debian/Ubuntu.
 
 This tool removes those kernel packages marked as candidate for autoremoval. Those packages are generally installed via Unattended upgrade or meta-packages. By default the latest kernel and manual installations are marked to Never Auto Remove.
 
 *thresher - A device that first separates the head of a stalk of grain from the straw, and then further separates the kernel from the rest of the head.*
 
+
 Supported Operating Systems
 ---------------------------
 
-* Debian (Tested on Version(s) 8)
-* Ubuntu (Tested on Version(s) 14.04, 15.10)
+* Debian (Tested on Version(s))
+  * [8](https://www.debian.org/releases/jessie/)
+* Ubuntu (Tested on Version(s))
+  * [14.04](http://releases.ubuntu.com/trusty/)
+  * [15.10](http://releases.ubuntu.com/trusty/)
+  * [16.04(development branch/Beta 2)](http://releases.ubuntu.com/xenial/)
+
 
 Installation
 -----
@@ -39,36 +45,137 @@ or
     git clone https://https://github.com/rackerlabs/kthresher.git
     python kthresher/setup.py install
 
+
 Usage
 -----
 
-    $ kthresher
-    usage: kthresher [-h] [-l] [-p] [-f] [-v]
+    $ kthresher -h
+    usage: kthresher [-h] [-d] [-n [N]] [-p] [-s] [-v] [-V]
     
     Purge Unused Kernels.
     
     optional arguments:
-      -h, --help         show this help message and exit
-      -l, --list-kernel  List unused kernel packages available to purge.
-      -p, --purge        Purge Unused Kernels.
-      -f, --force        Proceed without confirmation
-      -v, --version
+      -h, --help            show this help message and exit
+      -d, --dry-run         List unused kernel images available to purge(dry run)
+      -n [N], --number [N]  Number of kernels to keep, default 1.
+      -p, --purge           Purge Unused Kernels.
+      -s, --show-autoremoval
+                            Show kernel packages available for autoremoval.
+      -v, --verbose         Be verbose.
+      -V, --version         Print version.
+
 
 Examples
 --------
 
-    Listing the packages available to remove
-    ----------------------------------
-    # khresher -l
-    ## Running kernel: linux-image-3.16.0-45-generic [3.16.0-45.60~14.04.1]
-    linux-image-3.16.0-49-generic [3.16.0-49.65~14.04.1]
-    linux-image-3.16.0-48-generic [3.16.0-48.64~14.04.1]
-    linux-headers-3.16.0-49-generic [3.16.0-49.65~14.04.1]
-    linux-headers-3.16.0-48 [3.16.0-48.64~14.04.1]
-    linux-headers-3.16.0-49 [3.16.0-49.65~14.04.1]
-    linux-headers-3.16.0-48-generic [3.16.0-48.64~14.04.1]
-    linux-image-extra-3.16.0-49-generic [3.16.0-49.65~14.04.1]
-    linux-image-extra-3.16.0-48-generic [3.16.0-48.64~14.04.1]
+    List which kernel images and its dependencies would remove(dry run)
+    --------------------------------------------------------------------
+    # kthresher -d
+    INFO: ----- DRY RUN -----
+    INFO: Running kernel is linux-image-3.13.0-83-generic v[3.13.0-83.127]
+    INFO: Attempting to keep 1 kernel package(s)
+    INFO: Found 6 kernel image(s) installed and available for autoremoval
+    INFO: Pre-sorting: ['3.16.0-60.80~14.04.1', '3.13.0-63.103', '3.13.0-79.123', '3.16.0-33.44~14.04.1', '3.13.0-77.121', '3.13.0-24.47']
+    INFO: Post-sorting: ['3.13.0-24.47', '3.13.0-63.103', '3.13.0-77.121', '3.13.0-79.123', '3.16.0-33.44~14.04.1', '3.16.0-60.80~14.04.1']
+    INFO:   Purging packages from version: 3.13.0-24.47
+    INFO:           Purging: linux-image-3.13.0-24-generic
+    INFO:   Purging packages from version: 3.13.0-63.103
+    INFO:           Purging: linux-image-extra-3.13.0-63-generic
+    INFO:           Purging: linux-image-3.13.0-63-generic
+    INFO:   Purging packages from version: 3.13.0-77.121
+    INFO:           Purging: linux-image-3.13.0-77-generic
+    INFO:           Purging: linux-image-extra-3.13.0-77-generic
+    INFO:   Purging packages from version: 3.13.0-79.123
+    INFO:           Purging: linux-image-3.13.0-79-generic
+    INFO:           Purging: linux-image-extra-3.13.0-79-generic
+    INFO:   Purging packages from version: 3.16.0-33.44~14.04.1
+    INFO:           Purging: linux-image-3.16.0-33-generic
+
+    Show all kernel packages available for autoremoval
+    --------------------------------------------------
+    # kthresher -s
+    List of kernel packages available for autoremoval:
+                   Version Package
+              3.13.0.83.89 linux-generic
+              3.13.0-51.84 linux-headers-3.13.0-51
+              3.13.0-51.84 linux-headers-3.13.0-51-generic
+             3.13.0-71.114 linux-headers-3.13.0-71
+             3.13.0-71.114 linux-headers-3.13.0-71-generic
+             3.13.0-77.121 linux-headers-3.13.0-77
+             3.13.0-77.121 linux-headers-3.13.0-77-generic
+             3.13.0-79.123 linux-headers-3.13.0-79
+             3.13.0-79.123 linux-headers-3.13.0-79-generic
+              3.13.0-24.47 linux-image-3.13.0-24-generic
+             3.13.0-63.103 linux-image-3.13.0-63-generic
+             3.13.0-77.121 linux-image-3.13.0-77-generic
+             3.13.0-79.123 linux-image-3.13.0-79-generic
+      3.16.0-33.44~14.04.1 linux-image-3.16.0-33-generic
+      3.16.0-60.80~14.04.1 linux-image-3.16.0-60-generic
+             3.13.0-63.103 linux-image-extra-3.13.0-63-generic
+             3.13.0-77.121 linux-image-extra-3.13.0-77-generic
+             3.13.0-79.123 linux-image-extra-3.13.0-79-generic
+              3.13.0.83.89 linux-image-generic
+
+    Purge Unused Kernels, keep 4 kernels and be verbose
+    ---------------------------------------------------
+    # ./kthresher.py -p -n4 -v
+    INFO: Running kernel is linux-image-3.13.0-83-generic v[3.13.0-83.127]
+    INFO: Attempting to keep 4 kernel package(s)
+    INFO: Found 5 kernel image(s) installed and available for autoremoval
+    INFO: Pre-sorting: ['3.16.0-60.80~14.04.1', '3.13.0-79.123', '3.16.0-33.44~14.04.1', '3.13.0-63.103', '3.13.0-77.121']
+    INFO: Post-sorting: ['3.13.0-63.103', '3.13.0-77.121', '3.13.0-79.123', '3.16.0-33.44~14.04.1', '3.16.0-60.80~14.04.1']
+    INFO:   Purging packages from version: 3.13.0-63.103
+    INFO:           Purging: linux-image-extra-3.13.0-63-generic
+    INFO:           Purging: linux-image-3.13.0-63-generic
+    Fetched 0 B in 0s (0 B/s)
+    (Reading database ... 174333 files and directories currently installed.)
+    Removing linux-image-extra-3.13.0-63-generic (3.13.0-63.103) ...
+    run-parts: executing /etc/kernel/postinst.d/apt-auto-removal 3.13.0-63-generic /boot/vmlinuz-3.13.0-63-generic
+    run-parts: executing /etc/kernel/postinst.d/initramfs-tools 3.13.0-63-generic /boot/vmlinuz-3.13.0-63-generic
+    update-initramfs: Generating /boot/initrd.img-3.13.0-63-generic
+    run-parts: executing /etc/kernel/postinst.d/zz-update-grub 3.13.0-63-generic /boot/vmlinuz-3.13.0-63-generic
+    Generating grub configuration file ...
+    Found linux image: /boot/vmlinuz-3.16.0-60-generic
+    Found initrd image: /boot/initrd.img-3.16.0-60-generic
+    Found linux image: /boot/vmlinuz-3.16.0-33-generic
+    Found initrd image: /boot/initrd.img-3.16.0-33-generic
+    Found linux image: /boot/vmlinuz-3.13.0-83-generic
+    Found initrd image: /boot/initrd.img-3.13.0-83-generic
+    Found linux image: /boot/vmlinuz-3.13.0-79-generic
+    Found initrd image: /boot/initrd.img-3.13.0-79-generic
+    Found linux image: /boot/vmlinuz-3.13.0-77-generic
+    Found initrd image: /boot/initrd.img-3.13.0-77-generic
+    Found linux image: /boot/vmlinuz-3.13.0-63-generic
+    Found initrd image: /boot/initrd.img-3.13.0-63-generic
+    done
+    Purging configuration files for linux-image-extra-3.13.0-63-generic (3.13.0-63.103) ...
+    Removing linux-image-3.13.0-63-generic (3.13.0-63.103) ...
+    Examining /etc/kernel/postrm.d .
+    run-parts: executing /etc/kernel/postrm.d/initramfs-tools 3.13.0-63-generic /boot/vmlinuz-3.13.0-63-generic
+    update-initramfs: Deleting /boot/initrd.img-3.13.0-63-generic
+    run-parts: executing /etc/kernel/postrm.d/zz-update-grub 3.13.0-63-generic /boot/vmlinuz-3.13.0-63-generic
+    Generating grub configuration file ...
+    Found linux image: /boot/vmlinuz-3.16.0-60-generic
+    Found initrd image: /boot/initrd.img-3.16.0-60-generic
+    Found linux image: /boot/vmlinuz-3.16.0-33-generic
+    Found initrd image: /boot/initrd.img-3.16.0-33-generic
+    Found linux image: /boot/vmlinuz-3.13.0-83-generic
+    Found initrd image: /boot/initrd.img-3.13.0-83-generic
+    Found linux image: /boot/vmlinuz-3.13.0-79-generic
+    Found initrd image: /boot/initrd.img-3.13.0-79-generic
+    Found linux image: /boot/vmlinuz-3.13.0-77-generic
+    Found initrd image: /boot/initrd.img-3.13.0-77-generic
+    done
+    Purging configuration files for linux-image-3.13.0-63-generic (3.13.0-63.103) ...
+    Examining /etc/kernel/postrm.d .
+    run-parts: executing /etc/kernel/postrm.d/initramfs-tools 3.13.0-63-generic /boot/vmlinuz-3.13.0-63-generic
+    run-parts: executing /etc/kernel/postrm.d/zz-update-grub 3.13.0-63-generic /boot/vmlinuz-3.13.0-63-generic
+
+
+Known Issues
+------------
+Python3 support is currently broken due to a known disutils.LooseVersion [issue][2].
+
 
 Bugs
 ----
@@ -77,3 +184,4 @@ Submit Bug reports, feature requests via [issues][1].
 
 
 [1]: https://github.com/rackerlabs/kthresher/issues
+[2]: https://bugs.python.org/issue14894

--- a/kthresher/kthresher.py
+++ b/kthresher/kthresher.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
+
 # Copyright 2015 Tony Garcia
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,14 +22,21 @@ Those packages are generally installed via Unattended upgrade or meta-packages
 By default the latest kernel and manual installations are marked to Never
 Auto Remove.
 
+Ubuntu suggestions on how to remove kernels:
+  https://help.ubuntu.com/community/Lubuntu/Documentation/RemoveOldKernels
+It uses a shell script:
+http://bazaar.launchpad.net/~kirkland/byobu/trunk/view/head:/usr/bin/purge-old-kernels
+
 thresher - A device that first separates the head of a stalk of grain from
 the straw, and then further separates the kernel from the rest of the head.
 '''
 
 import re
 import sys
+import logging
 import argparse
 from platform import uname, dist
+from distutils.version import LooseVersion
 
 try:
     import apt
@@ -39,69 +47,142 @@ except ImportError:
               'python-apt and/or python3-apt packages provide it.',
               file=sys.stderr)
     else:
-        print('{} distro not supported'.format(distro), file=sys.stderr)
+        print('{0} distro not supported'.format(distro), file=sys.stderr)
     sys.exit(1)
 
 
-__version__ = "0.2.3"
+__version__ = "1.0.0"
 
 
-def kthreshing(purge=None, force=None):
-    '''Purge or list the unused kernels.
+def show_autoremovable_pkgs():
+    '''List all the kernel related packages available for autoremoval.
     '''
-    purging = []
+    packages = {}
+    ver_max_len = 0
     try:
         apt_cache = apt.Cache()
     except:
-        print('Error, unable to obtain the cache!')
+        print('Error, unable to obtain the cache!', file=sys.stderr)
         sys.exit(1)
-    current_kernel = uname()[2]
-    kernel_pkg = apt_cache["linux-image-%s" % current_kernel]
-    print('## Running kernel: {} [{}]'.format(kernel_pkg.name,
-                                              kernel_pkg.installed.version))
     for pkg_name in apt_cache.keys():
         pkg = apt_cache[pkg_name]
         if (
            (pkg.is_installed and pkg.is_auto_removable) and
-           (pkg.section == 'kernel' or re.match("^linux-", pkg_name))
+           (pkg.section == 'kernel' or re.match("^linux-.*$", pkg_name))
            ):
-            if purge:
-                pkg.mark_delete(purge=True)
-                purging.append(pkg.name)
-                print('Mark for deletion: {} [{}]'
-                      .format(pkg_name, pkg.installed.version))
-            else:
-                print('{} [{}]'.format(pkg_name,
-                                       pkg.installed.version))
-    if purging:
-        try:
-            apt_cache.commit()
-        except SystemError:
-            print('Unable to commit the changes')
+            packages[pkg_name] = pkg.installed.version
+            if ver_max_len < len(pkg.installed.version):
+                ver_max_len = len(pkg.installed.version)
+    if packages:
+        print('List of kernel packages available for autoremoval:')
+        print('{0:>{width}} {1:<{width}}'.format('Version', 'Package',
+              width=ver_max_len+2))
+        for package in sorted(packages.keys()):
+            print('{0:>{width}} {1:<{width}}'
+                  .format(packages[package], package, width=ver_max_len+2))
+    else:
+        print('No kernel packages available for autoremoval.')
+
+
+def kthreshing(purge=None, keep=1):
+    '''Purge or list the unused kernels.
+    By default keeps 1, besides the running kernel.
+    '''
+    kernels = {}
+    ver_max_len = 0
+    try:
+        apt_cache = apt.Cache()
+    except:
+        print('Error, unable to obtain the cache!', file=sys.stderr)
+        sys.exit(1)
+    current_kernel_ver = uname()[2]
+    kernel_pkg = apt_cache["linux-image-%s" % current_kernel_ver]
+    logging.info('Running kernel is {0} v[{1}]'.format(kernel_pkg.name,
+                 kernel_pkg.installed.version))
+    for pkg_name in apt_cache.keys():
+        pkg = apt_cache[pkg_name]
+        if (
+           (pkg.is_installed and pkg.is_auto_removable) and
+           (pkg.section == 'kernel' and
+            re.match("^linux-image-.*-generic$", pkg_name))
+           ):
+            if ver_max_len < len(pkg.installed.version):
+                ver_max_len = len(pkg.installed.version)
+            kernels.setdefault(pkg.installed.version, []).append(pkg.name)
+    if kernels:
+        logging.info('Attempting to keep {0} kernel package(s)'.format(keep))
+        kernel_versions = list(kernels.copy().keys())
+        logging.info('Found {0} kernel image(s) installed and available for '
+                     'autoremoval'.format(len(kernel_versions)))
+        logging.info('Pre-sorting: {0}'.format(kernel_versions))
+        # Sadly this is broken in python3, https://bugs.python.org/issue14894
+        sorted_kernel_list = sorted(kernel_versions, key=LooseVersion)
+        logging.info('Post-sorting: {0}'.format(sorted_kernel_list))
+        if keep >= len(kernel_versions):
+            logging.error('Nothing to do, attempting to keep {0} out of {1} '
+                          'kernel images.'
+                          .format(keep, len(kernel_versions)))
             sys.exit(1)
+        else:
+            for index in range(0, len(sorted_kernel_list) - keep):
+                kernel_version = sorted_kernel_list[index]
+                logging.info('\tPurging packages from version: {0}'
+                             .format(kernel_version))
+                for pkg_name in kernels[kernel_version]:
+                    logging.info('\t\tPurging: {0}'.format(pkg_name))
+                    if purge:
+                        pkg = apt_cache[pkg_name]
+                        pkg.mark_delete(purge=True)
+            if purge:
+                try:
+                    apt_cache.commit(
+                        fetch_progress=apt.progress.text.AcquireProgress(),
+                        install_progress=apt.progress.base.InstallProgress()
+                    )
+                except SystemError:
+                    logging.error('Unable to commit the changes')
+                    sys.exit(1)
+    else:
+        logging.info('No packages available for autoremoval.')
 
 
 def main():
     '''The main function.
     '''
-    parser = argparse.ArgumentParser(description='Purge Unused Kernels.')
-    parser.add_argument('-l', '--list-kernel', action='store_true',
-                        help='List unused kernel packages available to purge.')
+    parser = argparse.ArgumentParser(description='Purge Unused Kernels.',
+                                     prog='kthresher')
+    parser.add_argument('-d', '--dry-run', action='store_true',
+                        help='List unused kernel images available to purge'
+                        '(dry run)')
+    parser.add_argument('-n', '--number', nargs='?', type=int, default=1,
+                        help='Number of kernels to keep, default 1.', const=0,
+                        metavar='N', choices=range(0, 10))
     parser.add_argument('-p', '--purge', help='Purge Unused Kernels.',
                         action='store_true')
-    parser.add_argument('-f', '--force', help='Proceed without confirmation',
-                        action='store_true')
-    parser.add_argument('-v', '--version', action='store_true')
+    parser.add_argument('-s', '--show-autoremoval', action='store_true',
+                        help='Show kernel packages available for autoremoval.')
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help='Be verbose.')
+    parser.add_argument('-V', '--version', action='version',
+                        version='%(prog)s v{0}'.format(__version__),
+                        help='Print version.')
     args = parser.parse_args()
 
-    if args.version:
-        print('kthresher v{0}'.format(__version__))
-        return
-    if args.list_kernel:
-        kthreshing(purge=None)
+    if args.show_autoremoval:
+        show_autoremovable_pkgs()
+        sys.exit(0)
+    if args.dry_run or args.verbose:
+        log_level = logging.INFO
+    else:
+        log_level = logging.ERROR
+    logging.basicConfig(format='%(levelname)s: %(message)s',
+                        level=log_level)
+    if args.dry_run:
+        logging.info('----- DRY RUN -----')
+        kthreshing(purge=False, keep=args.number)
         sys.exit(0)
     if args.purge:
-        kthreshing(purge=True, force=args.force)
+        kthreshing(purge=True, keep=args.number)
         sys.exit(0)
     else:
         print('Error, no argument used.', file=sys.stderr)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 setuptools.setup(
     name='kthresher',
-    version='0.2.3',
+    version='1.0.0',
     description=('Tool to purge unused kernels.'),
     author='Tony Garcia',
     author_email='tony DOT garcia AT rackspace DOT com',
@@ -28,19 +28,14 @@ setuptools.setup(
     },
     packages=['kthresher'],
     url='https://github.com/rackerlabs/kthresher',
-    download_url='https://github.com/rackerlabs/kthresher/tarball/0.2.3',
+    download_url='https://github.com/rackerlabs/kthresher/tarball/1.0.0',
     zip_safe=False,
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python',
         'Environment :: Console',
         'Operating System :: POSIX :: Linux',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.1',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
     ]
 )


### PR DESCRIPTION
Had to refactor good chunk of the code for this, compatibility to previous version is now broken so bumping to version 1.0.0.
Added --dry-run and kept a similar functionality as previous version to list kernel packages available to autoremove(-s).

Solves #6
