### PR TITLE
Adding support for "old"i virtual kernel packages.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,7 @@ Supported Operating Systems
 * Debian (Tested on Version(s))
     * `8 <https://www.debian.org/releases/jessie/>`__
 * Ubuntu (Tested on Version(s))
+    * `12.04 <http://releases.ubuntu.com/precise/`__
     * `14.04 <http://releases.ubuntu.com/trusty/>`__
     * `15.10 <http://releases.ubuntu.com/wily/>`__
     * `16.04(development branch/Beta 2) <http://releases.ubuntu.com/xenial/>`__

--- a/kthresher/kthresher.py
+++ b/kthresher/kthresher.py
@@ -52,7 +52,7 @@ except ImportError:
     sys.exit(1)
 
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 
 def get_configs(conf_file, section):
@@ -160,8 +160,8 @@ def kthreshing(purge=None, headers=None, keep=1):
     '''
     kernels = {}
     ver_max_len = 0
-    kernel_image_regex = '^linux-image.*-generic$'
-    kernel_header_regex = '^linux-header.*(-generic)?$'
+    kernel_image_regex = '^linux-image.*(-generic|-virtual)$'
+    kernel_header_regex = '^linux-header.*(-generic|-virtual)?$'
     try:
         apt_cache = apt.Cache()
     except:


### PR DESCRIPTION
Virtual kernel packages were intented to be used for virtual instances but later deprecated in favor of linux-image-generic as outlined in https://help.ubuntu.com/community/ServerFaq#What_are_the_differences_between_the_server_and_virtual_kernels.3F.
