### PR TITLE
Non root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Added
+- Better error handling when executing as non-root.
+- Logos.
+
 ### Changed
 - Regex to include linux-headers ending in -common.
+- Improved the testing example on the README.
 
 ## [1.2.6] - 2017-01-30
 ### Added

--- a/README.rst
+++ b/README.rst
@@ -310,8 +310,9 @@ The below code can be used to install all the kernels and headers available of t
     And set them for autoremoval, so kthresher can be used for testing.
     '''
     
-    import apt
     import re
+    import apt
+    import sys
     from platform import uname
     
     def autorm_install(pkgs):
@@ -326,6 +327,9 @@ The below code can be used to install all the kernels and headers available of t
                 k.mark_install(from_user=False)
         try:
             ac.commit(install_progress=None)
+        except apt.cache.LockFailedException as lfe:
+            print('{}, are you root?'.format(lfe))
+            sys.exit(1)
         except SystemError:
             print('Something failed')
             sys.exit(1)
@@ -338,7 +342,7 @@ The below code can be used to install all the kernels and headers available of t
         kernels = []
         ac = apt.Cache()
         ac.update()
-        kernel_regex = "^linux-(image|headers)-\d\..*-(generic|amd64$"
+        kernel_regex = "^linux-(image|headers)-\d\..*-(generic|amd64)$"
         for pkg in ac:
             if re.match(kernel_regex, pkg.name):
                 if not pkg.name == 'linux-image-{0}'.format(uname()[2]):

--- a/kthresher.py
+++ b/kthresher.py
@@ -243,6 +243,9 @@ def kthreshing(purge=None, headers=None, keep=1):
                         fetch_progress=apt.progress.text.AcquireProgress(),
                         install_progress=apt.progress.base.InstallProgress()
                     )
+                except apt.cache.LockFailedException as lfe:
+                    logging.error('{}, are you root?'.format(lfe))
+                    sys.exit(1)
                 except SystemError:
                     logging.error('Unable to commit the changes')
                     sys.exit(1)


### PR DESCRIPTION
Fix #35 

```log
[tonyskapunk@gnu:~]$ python kthresher.py --purge --verbose                                                                          
INFO: Attempting to read /etc/kthresher.conf.
INFO: Options found: ['include'].
INFO: Valid setting found "include"
INFO:   include = /etc/kthresher.d/*.conf
INFO: Attempting to read /etc/kthresher.d/kthresher.conf.
INFO: Options found: ['purge', 'keep', 'headers', 'verbose'].
INFO: Valid setting found "purge"
INFO:   purge = True
INFO: Valid setting found "keep"
INFO:   keep = 0
INFO: Valid setting found "headers"
INFO:   headers = True
INFO: Valid setting found "verbose"
INFO:   verbose = True
INFO: Options: {'verbose': True, 'dry_run': False, 'keep': 0, 'purge': True, 'headers': True, 'include': '/etc/kthresher.d/*.conf'}
INFO: Running kernel is linux-image-4.9.0-2-amd64 v[4.9.13-1]
INFO: Attempting to keep 0 kernel package(s)
INFO: Found 1 kernel image(s) installed and available for autoremoval
INFO: Pre-sorting: ['3.16.7-ckt25-2']
INFO: Post-sorting: ['3.16.7-ckt25-2']
INFO:   Purging packages from version: 3.16.7-ckt25-2
INFO:           Purging: linux-image-3.16.0-4-amd64
ERROR: Failed to lock /var/cache/apt/archives/lock, are you root?
```