### PR TITLE
adding bash_completion logic

### DIFF
--- a/kthresher.bash_completion
+++ b/kthresher.bash_completion
@@ -5,7 +5,11 @@ containsElement()
   # 0 if string in $1 is in the array
   # 1 if not
   local e
-  for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0 ; done
+  for e in "${@:2}"; do
+    if [[ "${e}" == "${1}" ]]; then
+        return 0
+    fi
+  done
   return 1
 }
 
@@ -15,23 +19,22 @@ genOpts()
   local IFS
   local not_used=""
   # options in pairs
-  local opts="--help,-h --config,-c --dry-run,-d --headers,-H --keep,-k --purge,-p --show-autoremoval,-s --verbose,-v --version,-V"
+  local opts="--help,-h --config,-c --dry-run,-d --headers,-H --keep,-k --purge,-p "
+  opts+="--show-autoremoval,-s --verbose,-v --version,-V"
   for i in ${opts} ; do
-    OLDIFS=$IFS
+    OLDIFS=${IFS}
     # set IFS to split our pairs
     IFS=","
-    set -- $i
+    set -- ${i}``
     # reset IFS to original value
-    IFS=$OLDIFS
-    result_one=$(containsElement "${1}" "${COMP_WORDS[@]}" ; echo $?)
-    result_two=$(containsElement "${2}" "${COMP_WORDS[@]}" ; echo $?)
-    # if neither exists in COMP_WORDS, both short and long opt are valid for use
-    if [[ "${result_one}" != 0 ]] && [[ "${result_two}" != 0 ]]; then
-      not_used="${not_used} ${1}"
-      not_used="${not_used} ${2}"
+    IFS=${OLDIFS}
+    if ! $( containsElement "${1}" "${COMP_WORDS[@]}" ) && \
+       ! $( containsElement "${2}" "${COMP_WORDS[@]}" ); then
+         not_used="${not_used} ${1}"
+         not_used="${not_used} ${2}"
     fi
   done
-  echo "$not_used"
+  echo "${not_used}"
 }
 
 _kthresher()
@@ -39,7 +42,7 @@ _kthresher()
     local cur=${COMP_WORDS[COMP_CWORD]}
     local prev=${COMP_WORDS[COMP_CWORD-1]}
     #echo "Genopts $(genOpts) COMP_WORDS ${COMP_WORDS[@]}"
-    COMPREPLY=( $(compgen -W "$(genOpts)" -- $cur ) )
+    COMPREPLY=( $(compgen -W "$(genOpts)" -- ${cur} ) )
 }
 
 complete -F _kthresher kthresher

--- a/kthresher.bash_completion
+++ b/kthresher.bash_completion
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+containsElement()
+{
+  # 0 if string in $1 is in the array
+  # 1 if not
+  local e
+  for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0 ; done
+  return 1
+}
+
+genOpts()
+{
+  local OLDIFS
+  local IFS
+  local not_used=""
+  # options in pairs
+  local opts="--help,-h --config,-c --dry-run,-d --headers,-H --keep,-k --purge,-p --show-autoremoval,-s --verbose,-v --version,-V"
+  for i in ${opts} ; do
+    OLDIFS=$IFS
+    # set IFS to split our pairs
+    IFS=","
+    set -- $i
+    # reset IFS to original value
+    IFS=$OLDIFS
+    result_one=$(containsElement "${1}" "${COMP_WORDS[@]}" ; echo $?)
+    result_two=$(containsElement "${2}" "${COMP_WORDS[@]}" ; echo $?)
+    # if neither exists in COMP_WORDS, both short and long opt are valid for use
+    if [[ "${result_one}" != 0 ]] && [[ "${result_two}" != 0 ]]; then
+      not_used="${not_used} ${1}"
+      not_used="${not_used} ${2}"
+    fi
+  done
+  echo "$not_used"
+}
+
+_kthresher()
+{
+    local cur=${COMP_WORDS[COMP_CWORD]}
+    local prev=${COMP_WORDS[COMP_CWORD-1]}
+    #echo "Genopts $(genOpts) COMP_WORDS ${COMP_WORDS[@]}"
+    COMPREPLY=( $(compgen -W "$(genOpts)" -- $cur ) )
+}
+
+complete -F _kthresher kthresher

--- a/kthresher.bash_completion
+++ b/kthresher.bash_completion
@@ -5,7 +5,11 @@ containsElement()
   # 0 if string in $1 is in the array
   # 1 if not
   local e
-  for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0 ; done
+  for e in "${@:2}"; do
+    if [[ "${e}" == "${1}" ]]; then
+        return 0
+    fi
+  done
   return 1
 }
 
@@ -15,23 +19,22 @@ genOpts()
   local IFS
   local not_used=""
   # options in pairs
-  local opts="--help,-h --config,-c --dry-run,-d --headers,-H --keep,-k --purge,-p --show-autoremoval,-s --verbose,-v --version,-V"
+  local opts="--help,-h --config,-c --dry-run,-d --headers,-H --keep,-k --purge,-p "
+  opts+="--show-autoremoval,-s --verbose,-v --version,-V"
   for i in ${opts} ; do
-    OLDIFS=$IFS
+    OLDIFS=${IFS}
     # set IFS to split our pairs
     IFS=","
-    set -- $i
+    set -- ${i}``
     # reset IFS to original value
-    IFS=$OLDIFS
-    result_one=$(containsElement "${1}" "${COMP_WORDS[@]}" ; echo $?)
-    result_two=$(containsElement "${2}" "${COMP_WORDS[@]}" ; echo $?)
-    # if neither exists in COMP_WORDS, both short and long opt are valid for use
-    if [[ "${result_one}" != 0 ]] && [[ "${result_two}" != 0 ]]; then
-      not_used="${not_used} ${1}"
-      not_used="${not_used} ${2}"
+    IFS=${OLDIFS}
+    if ! $( containsElement "${1}" "${COMP_WORDS[@]}" ) && \
+       ! $( containsElement "${2}" "${COMP_WORDS[@]}" ); then
+         not_used="${not_used} ${1}"
+         not_used="${not_used} ${2}"
     fi
   done
-  echo "$not_used"
+  echo "${not_used}"
 }
 
 _kthresher()


### PR DESCRIPTION
Provides bash_completion functionality should someone find themselves using this via the cli for any reason.

Functionality should remove a short-flag if the corresponding long-flag has been called. Also should work if an argument takes a value.

Demonstration:

```
$ kthresher -<tab><tab>
--config            --help              --show-autoremoval  -H                  -d                  -p
--dry-run           --keep              --verbose           -V                  -h                  -s
--headers           --purge             --version           -c                  -k                  -v
$ kthresher --verbose -<tab><tab>
--config            --help              --show-autoremoval  -V                  -h                  -s
--dry-run           --keep              --version           -c                  -k
--headers           --purge             -H                  -d                  -p
$ kthresher --verbose -c file -<tab><tab>
--dry-run           --keep              --version           -d                  -p
--headers           --purge             -H                  -h                  -s
--help              --show-autoremoval  -V                  -k
$ kthresher --verbose -c file --dry-run
```

Did not specify install location, leaving it up to user or maintainer preference on whether it should be installed automatically or not.