### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ Github
 
 .. code-block:: bash
 
-    git clone https://https://github.com/rackerlabs/kthresher.git
+    git clone https://github.com/rackerlabs/kthresher.git
     cd kthresher && python setup.py install
 
 


### PR DESCRIPTION
removed extra 'https://' to allow for seamless copypasta install