### PR TITLE
Release 1.3.1 to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.3.1] - 2018-04-23
+### Added
+- Removed shell from bash completion.
+- Added license to bash completion.
+
 ## [1.3.0] - 2018-01-30
 ### Added
 - Bash completion

--- a/kthresher.bash_completion
+++ b/kthresher.bash_completion
@@ -1,4 +1,18 @@
-#!/usr/bin/env bash
+# bash completion for kthresher                            -*- shell-script -*-
+#
+# Copyright 2015-2018 Tony Garcia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 containsElement()
 {

--- a/kthresher.py
+++ b/kthresher.py
@@ -54,7 +54,7 @@ except ImportError:
     sys.exit(1)
 
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 
 def get_configs(conf_file, section):

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
                       'candidates for autoremoval.'),
     url='https://github.com/rackerlabs/kthresher',
     author='Tony Garcia',
-    author_email='tony DOT garcia AT rackspace DOT com',
+    author_email='tony.garcia@rackspace.com',
     license='Apache License, Version 2.0',
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
- Removing shell from bash completion
- Adding license to bash completion
- Bump to 1.3.1