### PR TITLE
Add systemd timer support

### DIFF
--- a/kthresher.systemd.service
+++ b/kthresher.systemd.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Purge unused kernels
+Documentation=man:kthresher(8)
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/kthresher

--- a/kthresher.systemd.timer
+++ b/kthresher.systemd.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run kthresher daily
+
+[Timer]
+OnCalendar=daily
+Persistent=True
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
### Provides Systemd Timer and associated service file for optional use.

Fixes #48 

### Considerations
* As far as frequency, `OnCalendar=daily` is being used to match the provided cron.daily file. This was tested using `OnCalendar=minutely` or equivalent (detailed below).
* The `.service` and `.timer` files have been tested with `systemd-analyze` where possible. This may be worth including in tests at a later time - if the test suite of choice has the capability.
* Tested against the following (python2.x provided by distribution repositories, kthresher installed via setup.py from source/development branch):
    * Ubuntu 16.04 
        * Versions
            * Python 2.7.12
            * Systemd 229-4ubuntu21.4
    * Ubuntu 18.04 
        * Versions
            * Python 2.7.15rc1
            * Systemd 237-3ubuntu10.3
    * Debian Jessie 
        * Version:
            * Python 2.7.9
            * Systemd 215-17+deb8u7
        * Notes
            * systemd does not allow for `OnCalendar=minutely` in this version, however daily is an option so `*-*-* *:*:00` was used for testing to simulate the same behavior as `minutely`.
            * `systemd-analyze` did not have a `verify` option in this version.
    * Debian Stretch 
        * Versions
            * Python 2.7.13
            * Systemd 232-25+deb9u4
* In testing, installation via setup.py results in install path at `/usr/local/bin/kthresher` - I've left `/usr/bin/kthresher` as the path to use to match the cron.daily example but testing was done at the specified path. Shouldn't impact anything, but we cannot dynamically build the path given the current installation procedure.
* From what I can see, the cron.daily entry should fail with a default configuration as there are no options specified (as in, help output should be displayed and a non-zero exit code should return). The default systemd service definition will have the --dry-run option such that by default nothing will happen, but the timer and service will not fail. This is mostly a precaution.