### PR TITLE
Remove use of section property from Package

### DIFF
--- a/kthresher.py
+++ b/kthresher.py
@@ -272,8 +272,9 @@ def kthreshing(purge=None, headers=None, keep=1):
     )
     for pkg_name in apt_cache.keys():
         pkg = apt_cache[pkg_name]
+        section = pkg.candidate.section or ''
         if (pkg.is_installed and pkg.is_auto_removable) and (
-            "kernel" in pkg.section and re.match(kernel_image_regex, pkg_name)
+            "kernel" in section and re.match(kernel_image_regex, pkg_name)
         ):
             if ver_max_len < len(pkg.installed.version):
                 ver_max_len = len(pkg.installed.version)


### PR DESCRIPTION
- Remove the use of `Package.section` for the use of `Version.section`

Fix: #80 

---

`apt` **1.9** is in experimental, likely will be included in `buster` coming release:
```shell
$ for c in experimental buster u19.04 u18.04 u16.04; do
    echo ${c} ===
    docker exec ${c} \
        python3 -c \
            'import apt; ac=apt.Cache(); print(ac["python3-apt"].candidate.version)';
done
=== experimental ===
1.9.0
=== buster ===
1.8.4
=== u19.04 ===
1.8.4
=== u18.04 ===
1.6.4
=== u16.04 ===
1.1.0~beta1ubuntu0.16.04.5
```

Here testing with the current code that uses `Package.section` showing that will fail in **1.9**
```shell
$ for c in experimental buster u19.04 u18.04 u16.04; do
    echo === ${c} ===
    docker exec ${c} \
    python3 -c \
        'import apt; ac=apt.Cache(); print(ac["python3-apt"].section)'
done
=== experimental ===
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AttributeError: 'Package' object has no attribute 'section'
=== buster ===
python
=== u19.04 ===
python
=== u18.04 ===
python
=== u16.04 ===
python
```

Here using `Version.section` instead (note that candidates produces a `Version` object):
```shell
$ for c in experimental buster u19.04 u18.04 u16.04; do
    echo === ${c} ===
    docker exec ${c} \
        python3 -c \
            'import apt; ac=apt.Cache(); print(ac["python3-apt"].candidate.section)'; done
=== experimental ===
python
=== buster ===
python
=== u19.04 ===
python
=== u18.04 ===
python
=== u16.04 ===
python
```