### PR TITLE
Fix AttributeError: 'NoneType' object has no attribute 'section'

### DIFF
--- a/kthresher.py
+++ b/kthresher.py
@@ -272,7 +272,10 @@ def kthreshing(purge=None, headers=None, keep=1):
     )
     for pkg_name in apt_cache.keys():
         pkg = apt_cache[pkg_name]
-        section = pkg.candidate.section or ''
+        try:
+            section = pkg.candidate.section
+        except:
+            section = ''
         if (pkg.is_installed and pkg.is_auto_removable) and (
             "kernel" in section and re.match(kernel_image_regex, pkg_name)
         ):


### PR DESCRIPTION
This is caused by packages that have no Section: defined.

Thanks: Matus UHLAR for the Debian bug report ([#996035](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=996035))

Thanks: @garaged for the patch

Closes: rackerlabs/kthresher#86